### PR TITLE
Initialize offline-first Flutter auth screens

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'features/auth/presentation/screens/sign_in_screen.dart';
+import 'features/auth/presentation/screens/sign_up_screen.dart';
+
+class EftarApp extends StatelessWidget {
+  const EftarApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'EFTAR App',
+      theme: ThemeData(
+        primarySwatch: Colors.teal,
+      ),
+      initialRoute: SignInScreen.routeName,
+      routes: {
+        SignInScreen.routeName: (_) => const SignInScreen(),
+        SignUpScreen.routeName: (_) => const SignUpScreen(),
+      },
+    );
+  }
+}

--- a/lib/core/services/local_storage_service.dart
+++ b/lib/core/services/local_storage_service.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LocalStorageService {
+  LocalStorageService._();
+  static final LocalStorageService instance = LocalStorageService._();
+
+  static const String _userKey = 'cached_user';
+
+  Future<void> cacheUser(Map<String, dynamic> user) async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = jsonEncode(user);
+    await prefs.setString(_userKey, jsonString);
+  }
+
+  Future<Map<String, dynamic>?> getCachedUser() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = prefs.getString(_userKey);
+    if (jsonString == null) return null;
+    return jsonDecode(jsonString) as Map<String, dynamic>;
+  }
+
+  Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_userKey);
+  }
+}

--- a/lib/features/auth/data/auth_repository.dart
+++ b/lib/features/auth/data/auth_repository.dart
@@ -1,0 +1,58 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:connectivity_plus/connectivity_plus.dart';
+import '../../../core/services/local_storage_service.dart';
+
+class AuthRepository {
+  final LocalStorageService _localStorage = LocalStorageService.instance;
+  final http.Client _client;
+
+  AuthRepository({http.Client? client}) : _client = client ?? http.Client();
+
+  Future<Map<String, dynamic>> signIn(String email, String password) async {
+    final connectivity = await Connectivity().checkConnectivity();
+    if (connectivity == ConnectivityResult.none) {
+      final cached = await _localStorage.getCachedUser();
+      if (cached != null && cached['email'] == email) {
+        return cached;
+      }
+      throw Exception('No internet connection and no cached user found');
+    }
+
+    // replace with real API endpoint
+    final response = await _client.post(
+      Uri.parse('https://example.com/api/signin'),
+      body: {'email': email, 'password': password},
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      await _localStorage.cacheUser(data);
+      return data;
+    }
+    throw Exception('Failed to sign in');
+  }
+
+  Future<Map<String, dynamic>> signUp(String email, String password) async {
+    final connectivity = await Connectivity().checkConnectivity();
+    if (connectivity == ConnectivityResult.none) {
+      throw Exception('No internet connection for sign up');
+    }
+
+    final response = await _client.post(
+      Uri.parse('https://example.com/api/signup'),
+      body: {'email': email, 'password': password},
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      await _localStorage.cacheUser(data);
+      return data;
+    }
+    throw Exception('Failed to sign up');
+  }
+
+  Future<void> signOut() async {
+    await _localStorage.clear();
+  }
+}

--- a/lib/features/auth/presentation/screens/sign_in_screen.dart
+++ b/lib/features/auth/presentation/screens/sign_in_screen.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import '../../data/auth_repository.dart';
+
+class SignInScreen extends StatefulWidget {
+  static const routeName = '/signin';
+
+  const SignInScreen({super.key});
+
+  @override
+  State<SignInScreen> createState() => _SignInScreenState();
+}
+
+class _SignInScreenState extends State<SignInScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _repository = AuthRepository();
+  bool _loading = false;
+  String? _error;
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      await _repository.signIn(
+        _emailController.text,
+        _passwordController.text,
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Signed in')));
+      }
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sign In')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email'),
+                validator: (v) => v!.isEmpty ? 'Enter email' : null,
+              ),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+                validator: (v) => v!.isEmpty ? 'Enter password' : null,
+              ),
+              const SizedBox(height: 20),
+              if (_error != null)
+                Text(_error!, style: const TextStyle(color: Colors.red)),
+              ElevatedButton(
+                onPressed: _loading ? null : _submit,
+                child: _loading
+                    ? const CircularProgressIndicator()
+                    : const Text('Sign In'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pushNamed(
+                  context,
+                  '/signup',
+                ),
+                child: const Text('Create an account'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/screens/sign_up_screen.dart
+++ b/lib/features/auth/presentation/screens/sign_up_screen.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import '../../data/auth_repository.dart';
+
+class SignUpScreen extends StatefulWidget {
+  static const routeName = '/signup';
+
+  const SignUpScreen({super.key});
+
+  @override
+  State<SignUpScreen> createState() => _SignUpScreenState();
+}
+
+class _SignUpScreenState extends State<SignUpScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _repository = AuthRepository();
+  bool _loading = false;
+  String? _error;
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      await _repository.signUp(
+        _emailController.text,
+        _passwordController.text,
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Account created')));
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sign Up')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email'),
+                validator: (v) => v!.isEmpty ? 'Enter email' : null,
+              ),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+                validator: (v) => v!.isEmpty ? 'Enter password' : null,
+              ),
+              const SizedBox(height: 20),
+              if (_error != null)
+                Text(_error!, style: const TextStyle(color: Colors.red)),
+              ElevatedButton(
+                onPressed: _loading ? null : _submit,
+                child: _loading
+                    ? const CircularProgressIndicator()
+                    : const Text('Sign Up'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+import 'app.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const EftarApp());
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,22 @@
+name: eftar_app
+description: Offline-first health tracking app
+
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  shared_preferences: ^2.0.15
+  connectivity_plus: ^3.0.2
+  http: ^0.13.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- scaffold a Flutter app structure with Material routing
- add LocalStorage service and auth repository for offline-first sign-in & sign-up
- implement sign-in and sign-up screens with basic forms

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b5ae5ff2c832f8cfc48140478f855